### PR TITLE
add verification to not save polls without choices

### DIFF
--- a/client/components/poll-form.js
+++ b/client/components/poll-form.js
@@ -18,8 +18,9 @@ Template.pollForm.events({
       }
     }
 
-    Polls.insert(newPoll);
-
-    window.location.replace( window.location.href + newPoll.name )
+    if (newPoll.choices.length > 1) {
+        Polls.insert(newPoll);
+        window.location.replace( window.location.href + newPoll.name )
+    }
   }
 });


### PR DESCRIPTION
### Scenario
* By adding the verification to not include blank choices, we introduced a bug that would save polls without choices, that is no more